### PR TITLE
Fix array helpers for RoundsArray

### DIFF
--- a/src/components/formComponents/roundsArray.tsx
+++ b/src/components/formComponents/roundsArray.tsx
@@ -15,17 +15,19 @@ import WorksetsArray from "./worksetsArray";
 type RoundsArrayProps = {
   values: Workout;
   workgroupIndex: number;
+  name: string;
 };
 export const RoundsArray: React.FC<RoundsArrayProps> = ({
   values,
-  workgroupIndex
+  workgroupIndex,
+  name
 }) => (
   <FieldArray
-    name="rounds"
+    name={name}
     render={roundsArrayHelpers => (
       <div>
         {values.workgroups[workgroupIndex].rounds.map((_round, roundIndex) => {
-          const roundFieldNamePrefix = `workgroups[${workgroupIndex}].rounds[${roundIndex}]`;
+          const roundFieldNamePrefix = `${name}[${roundIndex}]`;
           return (
             <div
               className={sectionStyle}

--- a/src/components/formComponents/workgroupsArray.tsx
+++ b/src/components/formComponents/workgroupsArray.tsx
@@ -42,7 +42,7 @@ export const WorkgroupsArray: React.FC<WorkgroupsArrayProps> = ({ values }) => (
                 fieldName={`${workgroupFieldNamePrefix}].notes`}
                 placeholder="Type notes here..."
               />
-              <RoundsArray values={values} workgroupIndex={workgroupIndex} />
+              <RoundsArray values={values} workgroupIndex={workgroupIndex} name={`${workgroupFieldNamePrefix}.rounds`} />
             </div>
           );
         })}


### PR DESCRIPTION

The `name` on the FieldArray needs to include the full path, including the ancestors.